### PR TITLE
Typo in options-resolver package.json (package name) and missing components in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Components available:
 ---------------------
 As said, Jymfony is made of reusable Javascript components:
 - `@jymfony/autoloader`
+- `@jymfony/cache`
 - `@jymfony/config`
 - `@jymfony/console`
 - `@jymfony/datetime`
@@ -33,6 +34,7 @@ As said, Jymfony is made of reusable Javascript components:
 - `@jymfony/filesystem`
 - `@jymfony/lexer`
 - `@jymfony/logger`
+- `@jymfomy/options-resolver`
 - `@jymfony/property-access`
 - `@jymfony/testing`
 

--- a/src/Component/OptionsResolver/package.json
+++ b/src/Component/OptionsResolver/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@jymfony/lexer",
+  "name": "@jymfony/options-resolver",
   "version": "0.1.0-dev",
   "description": "Jymfony OptionsResolver component",
   "scripts": {


### PR DESCRIPTION
Hey,
I noticed that the new components Cache and OptionsResolver were missing in the README. I've added those. Plus in OptionsResolver package.json the package name was still `lexer`, which is obviously a typo.