### PR TITLE
[Router] Fix JsFileLoader::load(resource) CWD management

### DIFF
--- a/src/Component/Routing/src/Loader/JsFileLoader.js
+++ b/src/Component/Routing/src/Loader/JsFileLoader.js
@@ -20,6 +20,8 @@ class JsFileLoader extends FileLoader {
      */
     load(resource) {
         const filePath = this._locator.locate(resource);
+        const previousCurrentDir = this.currentDir;
+
         this.currentDir = path.dirname(filePath);
 
         const code = '(function (loader) {\n'+fs.readFileSync(filePath)+'\n})';
@@ -34,6 +36,8 @@ class JsFileLoader extends FileLoader {
         script.runInThisContext({
             filename: filePath,
         })(collection, this);
+
+        this.currentDir = previousCurrentDir;
 
         return collection;
     }


### PR DESCRIPTION
JsFileLoader::load didn't restore the previous current working directory after executing the script.