### PR TITLE
[HttpFoundation] add websocket support

### DIFF
--- a/src/Bundle/FrameworkBundle/src/Resources/config/http-server.js
+++ b/src/Bundle/FrameworkBundle/src/Resources/config/http-server.js
@@ -40,3 +40,7 @@ container.register(Jymfony.Component.HttpServer.Command.HttpServerRunCommand)
     .addTag('console.command')
     .addArgument(new Reference(Jymfony.Component.HttpServer.HttpServer))
 ;
+
+container.register(Jymfony.Component.HttpServer.EventListener.WebsocketListener)
+    .addTag('kernel.event_subscriber')
+;

--- a/src/Bundle/SecurityBundle/src/DependencyInjection/Configuration.js
+++ b/src/Bundle/SecurityBundle/src/DependencyInjection/Configuration.js
@@ -10,14 +10,28 @@ const AccessDecisionManager = Jymfony.Component.Security.Authorization.AccessDec
  */
 class Configuration extends implementationOf(ConfigurationInterface) {
     /**
-     * @param {Jymfony.Bundle.SecurityBundle.DependencyInjection.UserProvider.UserProviderFactoryInterface[]} factories
+     * Constructor.
      */
-    set userProviderFactories(factories) {
+    __construct() {
         /**
          * @type {Jymfony.Bundle.SecurityBundle.DependencyInjection.UserProvider.UserProviderFactoryInterface[]}
          *
          * @private
          */
+        this._userProviderFactories = undefined;
+
+        /**
+         * @type {Object.<string, Jymfony.Bundle.SecurityBundle.DependencyInjection.Security.Factory.SecurityFactoryInterface>}
+         *
+         * @private
+         */
+        this._factories = undefined;
+    }
+
+    /**
+     * @param {Jymfony.Bundle.SecurityBundle.DependencyInjection.UserProvider.UserProviderFactoryInterface[]} factories
+     */
+    set userProviderFactories(factories) {
         this._userProviderFactories = factories;
     }
 
@@ -25,11 +39,6 @@ class Configuration extends implementationOf(ConfigurationInterface) {
      * @param {Object.<string, Jymfony.Bundle.SecurityBundle.DependencyInjection.Security.Factory.SecurityFactoryInterface>} factories
      */
     set factories(factories) {
-        /**
-         * @type {Object.<string, Jymfony.Bundle.SecurityBundle.DependencyInjection.Security.Factory.SecurityFactoryInterface>}
-         *
-         * @private
-         */
         this._factories = factories;
     }
 

--- a/src/Component/Autoloader/src/Parser/Patcher.js
+++ b/src/Component/Autoloader/src/Parser/Patcher.js
@@ -58,7 +58,7 @@ class Patcher {
             properties: {},
         };
 
-        let docblock = undefined, code = '', patchRemoval = () => {};
+        let docblock = undefined, code = ' ', patchRemoval = () => {};
         let hasConstructor = false;
 
         lexer.moveNext();

--- a/src/Component/Debug/src/Exception/UnhandledRejectionException.js
+++ b/src/Component/Debug/src/Exception/UnhandledRejectionException.js
@@ -1,3 +1,5 @@
+const util = require('util');
+
 /**
  * Debug exception thrown when an unhandled rejection event is fired.
  *
@@ -11,7 +13,18 @@ class UnhandledRejectionException extends RuntimeException {
      * @param {Error} previous
      */
     __construct(promise, previous = undefined) {
-        super.__construct('Unhandled rejection', null, previous);
+        let message = 'Unhandled promise rejection';
+        if (previous instanceof Error) {
+            message += ': ' + previous.toString();
+        } else {
+            message += '\nA non-Error object has been thrown to reject the promise\n\n';
+            message += util.inspect(previous, {
+                showProxy: true,
+                showHidden: true,
+            });
+        }
+
+        super.__construct(message, null, previous instanceof Error ? previous : undefined);
 
         /**
          * The promise which was rejected.

--- a/src/Component/EventDispatcher/src/DependencyInjection/Compiler/RegisterListenerPass.js
+++ b/src/Component/EventDispatcher/src/DependencyInjection/Compiler/RegisterListenerPass.js
@@ -33,6 +33,11 @@ class RegisterListenerPass extends implementationOf(CompilerPassInterface) {
         const definition = container.findDefinition(this.dispatcherService);
 
         for (const [ id, events ] of __jymfony.getEntries(container.findTaggedServiceIds(this.listenerTag))) {
+            const def = container.getDefinition(id);
+            if (def.isAbstract()) {
+                continue;
+            }
+
             for (const event of events) {
                 const priority = event.priority !== undefined ? event.priority : 0;
 
@@ -59,6 +64,9 @@ class RegisterListenerPass extends implementationOf(CompilerPassInterface) {
 
         for (const [ id ] of __jymfony.getEntries(container.findTaggedServiceIds(this.subscriberTag))) {
             const def = container.getDefinition(id);
+            if (def.isAbstract()) {
+                continue;
+            }
 
             const myclass = container.parameterBag.resolveValue(def.getClass());
             let myReflectionClass;

--- a/src/Component/HttpFoundation/namespace-stub.js
+++ b/src/Component/HttpFoundation/namespace-stub.js
@@ -45,4 +45,14 @@ Jymfony.Component.HttpFoundation = {
          */
         Storage: {},
     },
+
+    /**
+     * @namespace
+     */
+    Websocket: {
+        /**
+         * @namespace
+         */
+        Exception: {},
+    },
 };

--- a/src/Component/HttpFoundation/src/Response.js
+++ b/src/Component/HttpFoundation/src/Response.js
@@ -735,6 +735,36 @@ class Response {
     }
 
     /**
+     * Sends the response through the given ServerResponse object.
+     *
+     * @param {IncomingMessage} req
+     * @param {ServerResponse} res
+     *
+     * @returns {Promise<void>}
+     */
+    async sendResponse(req, res) {
+        if (res.respond) {
+            res.respond(Object.assign({ ':status': this.statusCode }, this.headers.all));
+        } else {
+            res.writeHead(this.statusCode, this.statusText, this.headers.all);
+        }
+
+        if (! this.isEmpty && this.content) {
+            if (isFunction(this.content)) {
+                await this.content(res);
+            } else {
+                await new Promise((resolve) => {
+                    res.write(this.content, 'utf8', () => {
+                        resolve();
+                    });
+                });
+            }
+        }
+
+        res.end();
+    }
+
+    /**
      * Checks if we need to remove Cache-Control for SSL encrypted downloads when using IE < 9.
      * @see http://support.microsoft.com/kb/323308
      *

--- a/src/Component/HttpFoundation/src/Websocket/Exception/BadFrameException.js
+++ b/src/Component/HttpFoundation/src/Websocket/Exception/BadFrameException.js
@@ -1,0 +1,7 @@
+/**
+ * @memberOf Jymfony.Component.HttpFoundation.Websocket.Exception
+ */
+class BadFrameException extends Exception {
+}
+
+module.exports = BadFrameException;

--- a/src/Component/HttpFoundation/src/Websocket/Exception/CloseFrameException.js
+++ b/src/Component/HttpFoundation/src/Websocket/Exception/CloseFrameException.js
@@ -1,0 +1,34 @@
+/**
+ * @memberOf Jymfony.Component.HttpFoundation.Websocket.Exception
+ */
+class CloseFrameException extends Exception {
+    /**
+     * Constructor.
+     *
+     * @param {Jymfony.Component.HttpFoundation.Websocket.Message} wsMessage
+     * @param {string} [message = 'Close request']
+     * @param {int|null} [code = null]
+     * @param {Exception} [previous]
+     */
+    __construct(wsMessage, message = 'Close request', code = null, previous = undefined) {
+        super.__construct(message, code, previous);
+
+        /**
+         * @type {Jymfony.Component.HttpFoundation.Websocket.Message}
+         *
+         * @private
+         */
+        this._websocketMessage = wsMessage;
+    }
+
+    /**
+     * The websocket message that generated the closing request.
+     *
+     * @returns {Jymfony.Component.HttpFoundation.Websocket.Message}
+     */
+    get websocketMessage() {
+        return this._websocketMessage;
+    }
+}
+
+module.exports = CloseFrameException;

--- a/src/Component/HttpFoundation/src/Websocket/Frame.js
+++ b/src/Component/HttpFoundation/src/Websocket/Frame.js
@@ -1,0 +1,149 @@
+/**
+ * @memberOf Jymfony.Component.HttpFoundation.Websocket
+ */
+class Frame {
+    /**
+     * Constructor.
+     */
+    __construct() {
+        /**
+         * @type {boolean}
+         */
+        this.fin = false;
+
+        /**
+         * @type {boolean}
+         */
+        this.rsv1 = false;
+
+        /**
+         * @type {boolean}
+         */
+        this.rsv2 = false;
+
+        /**
+         * @type {boolean}
+         */
+        this.rsv3 = false;
+
+        /**
+         * @type {number}
+         */
+        this.opcode = undefined;
+
+        /**
+         * @type {number[]}
+         */
+        this.mask = undefined;
+
+        /**
+         * @type {Buffer}
+         */
+        this.buffer = Buffer.allocUnsafe(0);
+    }
+
+    /**
+     * Converts this frame to a Buffer.
+     *
+     * @returns {Buffer}
+     */
+    toBuffer() {
+        const bufLen = 2 +
+            (126 > this.buffer.length ? 0 : 0xFFFF > this.buffer.length ? 2 : 8) +
+            (undefined !== this.mask ? 4 : 0)
+        ;
+
+        const buf = Buffer.allocUnsafe(bufLen);
+        const byte = this.opcode +
+            (this.fin ? 0x80 : 0) +
+            (this.rsv1 ? 0x40 : 0) +
+            (this.rsv2 ? 0x20 : 0) +
+            (this.rsv3 ? 0x10 : 0);
+
+        buf.writeUInt8(byte, 0);
+
+        if (126 > this.buffer.length) {
+            buf.writeUInt8(this.buffer.length, 1);
+        } else if (0xFFFF > this.buffer.length) {
+            buf.writeUInt8(126, 1);
+            buf.writeUInt16BE(this.buffer.length, 2);
+        } else {
+            buf.writeUInt8(127, 1);
+            buf.writeUIntBE(this.buffer.length, 2, 8);
+        }
+
+        const copy = Buffer.allocUnsafe(this.buffer.length);
+        this.buffer.copy(copy);
+
+        if (undefined !== this.mask) {
+            for (let i = 0; i < copy.length; i++) {
+                copy[i] = copy[i] ^ this.mask[i % 4];
+            }
+        }
+
+        return Buffer.concat([ buf, ...(this.mask || []), copy ]);
+    }
+
+    /**
+     * Initializes a frame from Buffer.
+     *
+     * @param {Buffer} buffer
+     *
+     * @returns {null|[Jymfony.Component.HttpFoundation.Websocket.Frame, Buffer]}
+     */
+    static fromBuffer(buffer) {
+        if (2 >= buffer.length) {
+            return null;
+        }
+
+        const obj = new __self();
+        let headerLen = 2;
+
+        const byte = buffer.readUInt8(0);
+        obj.fin = 0x80 === (byte & 0x80);
+        obj.rsv1 = 0x40 === (byte & 0x40);
+        obj.rsv2 = 0x20 === (byte & 0x20);
+        obj.rsv3 = 0x10 === (byte & 0x10);
+
+        obj.opcode = buffer.readUInt8(0) & 0xF;
+        const [ masked, length ] = ((byte) => {
+            let len = byte & 0x7F;
+            switch (len) {
+                case 126:
+                    len = buffer.readUInt16BE(2);
+                    headerLen += 2;
+                    break;
+
+                case 127:
+                    len = buffer.readUIntBE(2, 8);
+                    headerLen += 8;
+                    break;
+            }
+
+            return [
+                0x80 === (byte & 0x80),
+                len,
+            ];
+        })(buffer.readUInt8(1));
+
+        if (buffer.length < (masked ? headerLen + 4 : headerLen)) {
+            return null;
+        }
+
+        obj.mask = masked ? [ ...buffer.slice(headerLen, headerLen + 4) ] : undefined;
+        headerLen += masked ? 4 : 0;
+
+        if (buffer.length < headerLen + length) {
+            return null;
+        }
+
+        obj.buffer = buffer.slice(headerLen, headerLen + length);
+        for (let i = 0; i < obj.buffer.length; i++) {
+            obj.buffer[i] = obj.buffer[i] ^ obj.mask[i % 4];
+        }
+
+        return [ obj, buffer.slice(headerLen + length) ];
+    }
+}
+
+module.exports = Frame;

--- a/src/Component/HttpFoundation/src/Websocket/FrameBuffer.js
+++ b/src/Component/HttpFoundation/src/Websocket/FrameBuffer.js
@@ -1,0 +1,115 @@
+const BadFrameException = Jymfony.Component.HttpFoundation.Websocket.Exception.BadFrameException;
+const CloseFrameException = Jymfony.Component.HttpFoundation.Websocket.Exception.CloseFrameException;
+const Frame = Jymfony.Component.HttpFoundation.Websocket.Frame;
+const Message = Jymfony.Component.HttpFoundation.Websocket.Message;
+
+/**
+ * Utility class to decode a websocket frame.
+ *
+ * @memberOf Jymfony.Component.HttpFoundation.Websocket
+ * @internal
+ */
+class FrameBuffer {
+    /**
+     * Constructor.
+     */
+    __construct() {
+        /**
+         * Temporary buffer.
+         *
+         * @type {Buffer}
+         *
+         * @private
+         */
+        this._buffer = Buffer.allocUnsafe(0);
+
+        /**
+         * Incomplete frames buffer.
+         *
+         * @type {Jymfony.Component.HttpFoundation.Websocket.Frame[]}
+         *
+         * @private
+         */
+        this._frames = [];
+    }
+
+    /**
+     * Adds data, generates decoded messages.
+     *
+     * @param {Buffer} data
+     *
+     * @returns {IterableIterator<Jymfony.Component.HttpFoundation.Websocket.Message>}
+     */
+    * concat(data) {
+        this._buffer = Buffer.concat([ this._buffer, data ]);
+        let ret;
+
+        while (true) {
+            ret = Frame.fromBuffer(this._buffer);
+            if (! ret) {
+                return;
+            }
+
+            [ data, this._buffer ] = ret;
+
+            switch (data.opcode) {
+                case 0x8:
+                    throw new CloseFrameException(
+                        new Message(data.buffer, Message.TYPE_BINARY)
+                    );
+
+                case 0x9:
+                    // Ping frame.
+                    yield new Message(null, Message.TYPE_PING);
+                    break;
+
+                case 0xA:
+                    // Pong frame. Ignore
+                    break;
+
+                default:
+                    this._addFrame(data);
+
+                    if (data.fin) {
+                        yield this._buildMessage();
+                    }
+
+                    break;
+            }
+        }
+    }
+
+    /**
+     * Adds a frame to the buffer.
+     *
+     * @param {Jymfony.Component.HttpFoundation.Websocket.Frame} frame
+     *
+     * @private
+     */
+    _addFrame(frame) {
+        if (0 < this._frames.length && 0 !== frame.opcode) {
+            throw new BadFrameException('Bad frame received. Closing connection.');
+        }
+
+        this._frames.push(frame);
+    }
+
+    /**
+     * Builds a message from the buffered frames.
+     *
+     * @returns {Jymfony.Component.HttpFoundation.Websocket.Message}
+     *
+     * @private
+     */
+    _buildMessage() {
+        const message = new Message(
+            Buffer.concat(this._frames.map(pkt => pkt.buffer)),
+            1 === this._frames[0].opcode ? Message.TYPE_TEXT : Message.TYPE_BINARY
+        );
+
+        this._frames = [];
+        return message;
+    }
+}
+
+module.exports = FrameBuffer;

--- a/src/Component/HttpFoundation/src/Websocket/Message.js
+++ b/src/Component/HttpFoundation/src/Websocket/Message.js
@@ -1,0 +1,65 @@
+/**
+ * @memberOf Jymfony.Component.HttpFoundation.Websocket
+ */
+class Message {
+    /**
+     * Constructor.
+     *
+     * @param {Buffer|string} data
+     * @param {string} type
+     */
+    __construct(data, type = undefined) {
+        if (undefined === type) {
+            type = isString(data) ? __self.TYPE_TEXT : __self.TYPE_BINARY;
+        }
+
+        /**
+         * @type {Buffer}
+         *
+         * @private
+         */
+        this._buffer = Buffer.from(data);
+
+        /**
+         * @type {string}
+         *
+         * @private
+         */
+        this._type = type;
+    }
+
+    /**
+     * The message type.
+     *
+     * @returns {string}
+     */
+    get type() {
+        return this._type;
+    }
+
+    /**
+     * Gets the message data as buffer.
+     *
+     * @returns {Buffer}
+     */
+    asBuffer() {
+        return Buffer.from(this._buffer);
+    }
+
+    /**
+     * Gets the message data as string.
+     *
+     * @param {string} encoding
+     *
+     * @returns {String}
+     */
+    asString(encoding = 'utf8') {
+        return this._buffer.toString(encoding);
+    }
+}
+
+Message.TYPE_TEXT = 'text';
+Message.TYPE_BINARY = 'binary';
+Message.TYPE_PING = 'ping';
+
+module.exports = Message;

--- a/src/Component/HttpFoundation/src/Websocket/Websocket.js
+++ b/src/Component/HttpFoundation/src/Websocket/Websocket.js
@@ -1,0 +1,61 @@
+const Frame = Jymfony.Component.HttpFoundation.Websocket.Frame;
+const Message = Jymfony.Component.HttpFoundation.Websocket.Message;
+
+/**
+ * Base class for websocket handlers.
+ *
+ * @memberOf Jymfony.Component.HttpFoundation.Websocket
+ */
+class Websocket {
+    __construct() {
+        /**
+         * The websocket response (used to send data).
+         *
+         * @type {Jymfony.Component.HttpFoundation.Websocket.WebsocketResponse}
+         */
+        this._response = undefined;
+    }
+
+    /**
+     * The current websocket response.
+     *
+     * @param {Jymfony.Component.HttpFoundation.Websocket.WebsocketResponse} response
+     */
+    set response(response) {
+        this._response = response;
+    }
+
+    /**
+     * Sends a message through the websocket.
+     *
+     * @param {Jymfony.Component.HttpFoundation.Websocket.Message} message
+     *
+     * @return {Promise<void>}
+     */
+    send(message) {
+        const frame = new Frame();
+        frame.opcode = Message.TYPE_TEXT === message.type ? 0x1 : 0x2;
+        frame.fin = true;
+        frame.buffer = message.asBuffer();
+
+        return this._response._sendFrame(frame);
+    }
+
+    /**
+     * Handles websocket message.
+     *
+     * @param {Jymfony.Component.HttpFoundation.Websocket.Message} message
+     *
+     * @returns {Promise<void>}
+     */
+    async onMessage(message) { } // eslint-disable-line no-unused-vars
+
+    /**
+     * Handles websocket message.
+     *
+     * @returns {Promise<void>}
+     */
+    async onClose() { } // eslint-disable-line no-unused-vars
+}
+
+module.exports = Websocket;

--- a/src/Component/HttpFoundation/src/Websocket/WebsocketResponse.js
+++ b/src/Component/HttpFoundation/src/Websocket/WebsocketResponse.js
@@ -1,0 +1,251 @@
+const EventSubscriberInterface = Jymfony.Component.EventDispatcher.EventSubscriberInterface;
+const Response = Jymfony.Component.HttpFoundation.Response;
+const CloseFrameException = Jymfony.Component.HttpFoundation.Websocket.Exception.CloseFrameException;
+const Frame = Jymfony.Component.HttpFoundation.Websocket.Frame;
+const FrameBuffer = Jymfony.Component.HttpFoundation.Websocket.FrameBuffer;
+const Message = Jymfony.Component.HttpFoundation.Websocket.Message;
+const HttpServerEvents = Jymfony.Component.HttpServer.Event.HttpServerEvents;
+const crypto = require('crypto');
+
+/**
+ * @memberOf Jymfony.Component.HttpFoundation.Websocket
+ */
+class WebsocketResponse extends mix(Response, EventSubscriberInterface) {
+    /**
+     * Constructor.
+     *
+     * @param {Jymfony.Component.HttpFoundation.Websocket.Websocket} websocket
+     * @param {Object.<string, string|string[]>} headers
+     */
+    __construct(websocket, headers = {}) {
+        super.__construct(undefined, Response.HTTP_SWITCHING_PROTOCOLS, headers);
+
+        /**
+         * @type {net.Socket}
+         *
+         * @private
+         */
+        this._socket = undefined;
+
+        /**
+         * @type {boolean}
+         *
+         * @private
+         */
+        this._connected = false;
+
+        /**
+         * @type {Jymfony.Component.HttpFoundation.Websocket.FrameBuffer}
+         *
+         * @private
+         */
+        this._frameBuffer = new FrameBuffer();
+
+        /**
+         * @type {Jymfony.Component.HttpFoundation.Websocket.Websocket}
+         *
+         * @private
+         */
+        this._websocket = websocket;
+
+        /**
+         * @type {Jymfony.Component.EventDispatcher.EventDispatcherInterface}
+         *
+         * @private
+         */
+        this._eventDispatcher = undefined;
+    }
+
+    /**
+     * Subscribe to the given event dispatcher.
+     *
+     * @param {Jymfony.Component.EventDispatcher.EventDispatcherInterface} dispatcher
+     */
+    set eventDispatcher(dispatcher) {
+        this._eventDispatcher = dispatcher;
+        dispatcher.addSubscriber(this);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    prepare(request) {
+        super.prepare(request);
+
+        this.headers.set('Upgrade', 'websocket');
+        this.headers.set('Connection', 'upgrade');
+
+        const sha1 = crypto.createHash('sha1');
+        sha1.update(request.headers.get('Sec-WebSocket-Key') + __self.RFC6455_GUID);
+        this.headers.set('Sec-WebSocket-Accept', sha1.digest('base64'));
+
+        return this;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    sendResponse(req, res) {
+        this._socket = req.socket;
+        if (res.respond) {
+            res.respond(Object.assign({ ':status': this.statusCode }, this.headers.all));
+        } else {
+            res.writeHead(this.statusCode, this.statusText, this.headers.all);
+        }
+
+        this._websocket.response = this;
+
+        const pingTimer = setInterval(this._sendPing.bind(this), 60000);
+        this._connected = true;
+
+        this._socket.on('data', this._handleWebSocketData.bind(this));
+        this._socket.on('close', () => {
+            this._connected = false;
+            this._eventDispatcher.removeSubscriber(this);
+            clearInterval(pingTimer);
+        });
+    }
+
+    /**
+     * Closes the websocket connection.
+     *
+     * @param {int|string} reason
+     *
+     * @returns {Promise<void>}
+     */
+    async closeConnection(reason = __self.CLOSE_NORMAL) {
+        if (! this._connected) {
+            return;
+        }
+
+        await this._websocket.onClose();
+
+        const frame = new Frame();
+        frame.opcode = 0x8;
+        frame.fin = true;
+
+        if (isString(reason)) {
+            frame.buffer = Buffer.allocUnsafe(2 + reason.length);
+            frame.buffer.writeUInt16BE(__self.CLOSE_NORMAL, 0);
+            frame.buffer.write(reason, 2);
+        } else {
+            frame.buffer = Buffer.allocUnsafe(2);
+            frame.buffer.writeUInt16BE(reason, 0);
+        }
+
+        this._connected = false;
+        await this._sendFrame(frame);
+        this._socket.end();
+    }
+
+    /**
+     * Called upon http server termination.
+     *
+     * @return {Promise<void>}
+     */
+    onTerminate() {
+        return this.closeConnection(__self.CLOSE_SHUTDOWN);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    static getSubscribedEvents() {
+        return {
+            [HttpServerEvents.SERVER_TERMINATE]: 'onTerminate',
+        };
+    }
+
+    /**
+     * Handles incoming data from websocket.
+     *
+     * @param {Buffer} data
+     *
+     * @private
+     */
+    async _handleWebSocketData(data) {
+        try {
+            for (const message of this._frameBuffer.concat(data)) {
+                if (message.type === Message.TYPE_PING) {
+                    await this._sendPong(message);
+                    continue;
+                }
+
+                await this._websocket.onMessage(message);
+            }
+        } catch (e) {
+            if (e instanceof CloseFrameException) {
+                await this.closeConnection();
+                return;
+            }
+
+            await this.closeConnection(__self.CLOSE_ERROR);
+        }
+    }
+
+    /**
+     * Sends a ping request.
+     *
+     * @returns {Promise<void>}
+     *
+     * @private
+     */
+    _sendPing() {
+        const frame = new Frame();
+        frame.opcode = 0x9;
+        frame.fin = true;
+
+        return this._sendFrame(frame);
+    }
+
+    /**
+     * Sends a pong in response to a ping request.
+     *
+     * @param {Jymfony.Component.HttpFoundation.Websocket.Message} message
+     *
+     * @returns {Promise<void>}
+     *
+     * @private
+     */
+    _sendPong(message) {
+        const frame = new Frame();
+        frame.opcode = 0xA;
+        frame.fin = true;
+        frame.buffer = message.asBuffer();
+
+        return this._sendFrame(frame);
+    }
+
+    /**
+     * Sends a frame.
+     *
+     * @param {Jymfony.Component.HttpFoundation.Websocket.Frame} frame
+     *
+     * @returns {Promise<void>}
+     *
+     * @private
+     */
+    _sendFrame(frame) {
+        if (! this._connected) {
+            return Promise.resolve();
+        }
+
+        return new Promise(((resolve, reject) => {
+            this._socket.write(frame.toBuffer(), (err) => {
+                if (err) {
+                    reject(err);
+                }
+
+                resolve();
+            });
+        }));
+    }
+}
+
+WebsocketResponse.CLOSE_NORMAL = 1000;
+WebsocketResponse.CLOSE_SHUTDOWN = 1001;
+WebsocketResponse.CLOSE_ERROR = 1002;
+
+WebsocketResponse.RFC6455_GUID = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11';
+
+module.exports = WebsocketResponse;

--- a/src/Component/HttpServer/src/Command/HttpServerRunCommand.js
+++ b/src/Component/HttpServer/src/Command/HttpServerRunCommand.js
@@ -55,7 +55,9 @@ Starts the server and listen on port 8080 on localhost address only.`
             'Press Ctrl-C to exit',
         ]);
 
-        process.on('SIGINT', () => this._server.close());
+        process.on('SIGINT', async () => {
+            await this._server.close();
+        });
 
         try {
             await p;

--- a/src/Component/HttpServer/src/Event/GetResponseForControllerResultEvent.js
+++ b/src/Component/HttpServer/src/Event/GetResponseForControllerResultEvent.js
@@ -1,0 +1,35 @@
+const GetResponseEvent = Jymfony.Component.HttpServer.Event.GetResponseEvent;
+
+/**
+ * @memberOf Jymfony.Component.HttpServer.Event
+ */
+class GetResponseForControllerResultEvent extends GetResponseEvent {
+    /**
+     * Constructor.
+     *
+     * @param {Jymfony.Component.HttpServer.HttpServer} server
+     * @param {Jymfony.Component.HttpFoundation.Request} request
+     * @param {*} controllerResult
+     */
+    __construct(server, request, controllerResult) {
+        /**
+         * @type {*}
+         *
+         * @private
+         */
+        this._controllerResult = controllerResult;
+
+        super.__construct(server, request);
+    }
+
+    /**
+     * The controller return value.
+     *
+     * @returns {*}
+     */
+    get controllerResult() {
+        return this._controllerResult;
+    }
+}
+
+module.exports = GetResponseForControllerResultEvent;

--- a/src/Component/HttpServer/src/Event/HttpServerEvents.js
+++ b/src/Component/HttpServer/src/Event/HttpServerEvents.js
@@ -11,4 +11,6 @@ HttpServerEvents.RESPONSE = 'http.response';
 HttpServerEvents.TERMINATE = 'http.terminate';
 HttpServerEvents.FINISH_REQUEST = 'http.finish_request';
 
+HttpServerEvents.SERVER_TERMINATE = 'http.server_terminate';
+
 module.exports = HttpServerEvents;

--- a/src/Component/HttpServer/src/EventListener/WebsocketListener.js
+++ b/src/Component/HttpServer/src/EventListener/WebsocketListener.js
@@ -1,0 +1,92 @@
+const EventSubscriberInterface = Jymfony.Component.EventDispatcher.EventSubscriberInterface;
+const HttpException = Jymfony.Component.HttpFoundation.Exception.HttpException;
+const Request = Jymfony.Component.HttpFoundation.Request;
+const Response = Jymfony.Component.HttpFoundation.Response;
+const Websocket = Jymfony.Component.HttpFoundation.Websocket.Websocket;
+const WebsocketResponse = Jymfony.Component.HttpFoundation.Websocket.WebsocketResponse;
+const Events = Jymfony.Component.HttpServer.Event.HttpServerEvents;
+
+/**
+ * @memberOf Jymfony.Component.HttpServer.EventListener
+ */
+class WebsocketListener extends implementationOf(EventSubscriberInterface) {
+    /**
+     * Validates the websocket version.
+     *
+     * @param {Jymfony.Component.HttpServer.Event.GetResponseEvent} event
+     */
+    onRequest(event) {
+        const request = event.request;
+        if (request.attributes.has(Request.ATTRIBUTE_PARENT_REQUEST)) {
+            return; // Avoid loops
+        }
+
+        if (! request.headers.has('Sec-WebSocket-Key')) {
+            return;
+        }
+
+        if (! request.headers.has('Sec-WebSocket-Version')) {
+            throw new HttpException(Response.HTTP_BAD_REQUEST, 'Client must provide a value for Sec-WebSocket-Version.');
+        }
+
+        const websocketVersion = ~~request.headers.get('Sec-WebSocket-Version');
+        switch (websocketVersion) {
+            case 8:
+                request.headers.set('Origin', request.headers.get('Sec-WebSocket-Origin'));
+                break;
+
+            case 13:
+                break;
+
+            default:
+                throw new HttpException(Response.HTTP_UPGRADE_REQUIRED, __jymfony.sprintf(
+                    'Unsupported websocket client version: %s. Only versions 8 and 13 are supported.',
+                    websocketVersion
+                ));
+        }
+
+        request.attributes.set('_websocket_version', ~~websocketVersion);
+    }
+
+    /**
+     * @param {Jymfony.Component.HttpServer.Event.FilterResponseEvent} event
+     * @param {string} eventName
+     * @param {Jymfony.Component.EventDispatcher.EventDispatcherInterface} dispatcher
+     */
+    onResponse(event, eventName, dispatcher) {
+        const request = event.request;
+        const response = event.response;
+
+        if (event.response instanceof WebsocketResponse) {
+            event.response.eventDispatcher = dispatcher;
+        }
+
+        if (8 === request.attributes.get('_websocket_version')) {
+            response.headers.set('Sec-WebSocket-Origin', response.headers.get('Origin'));
+        }
+    }
+
+    /**
+     * @param {Jymfony.Component.HttpServer.Event.GetResponseForControllerResultEvent} event
+     */
+    onView(event) {
+        const result = event.controllerResult;
+
+        if (result instanceof Websocket) {
+            event.response = new WebsocketResponse(result);
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    static getSubscribedEvents() {
+        return {
+            [Events.REQUEST]: [ 'onRequest', 128 ],
+            [Events.VIEW]: [ 'onView', 15 ],
+            [Events.RESPONSE]: [ 'onResponse', -128 ],
+        };
+    }
+}
+
+module.exports = WebsocketListener;

--- a/src/Component/Logger/src/Handler/StreamHandler.js
+++ b/src/Component/Logger/src/Handler/StreamHandler.js
@@ -18,26 +18,38 @@ class StreamHandler extends AbstractProcessingHandler {
     __construct(stream, level = LogLevel.DEBUG, bubble = true, filePermission = undefined) {
         super.__construct(level, bubble);
 
-        if (isString(stream)) {
-            /**
-             * @type {string}
-             *
-             * @private
-             */
-            this._file = stream;
+        /**
+         * @type {string}
+         *
+         * @private
+         */
+        this._file = undefined;
 
-            /**
-             * @type {string}
-             *
-             * @private
-             */
+        /**
+         * @type {string}
+         *
+         * @private
+         */
+        this._filePermission = undefined;
+
+        /**
+         * @type {Writable}
+         *
+         * @private
+         */
+        this._stream = undefined;
+
+        /**
+         * @type {boolean}
+         *
+         * @private
+         */
+        this._dirCreated = false;
+
+        if (isString(stream)) {
+            this._file = stream;
             this._filePermission = filePermission;
         } else {
-            /**
-             * @type {Writable}
-             *
-             * @private
-             */
             this._stream = stream;
         }
     }

--- a/src/Component/Routing/src/Dumper/JsMatcherDumper.js
+++ b/src/Component/Routing/src/Dumper/JsMatcherDumper.js
@@ -107,7 +107,7 @@ module.exports = ${options['class']};
         const host = request.host.toLowerCase();
         const scheme = request.scheme;
         
-        let ret, requiredHost, requiredMethods, requiredSchemes;
+        let ret, requiredHost, requiredMethods, requiredSchemes, hasRequiredScheme;
 
         const requestMethod = request.method;
         let canonicalMethod = request.method;
@@ -719,7 +719,7 @@ ${combine}${this._compileRoute(route, name, false)}
             schemes = __self.export(schemes);
             if (0 < methods.length) {
                 code += `
-            requiredSchemes = schemes;
+            requiredSchemes = ${schemes};
             hasRequiredScheme = -1 !== requiredSchemes.indexOf(request.scheme);
             
             if (-1 === ${methods}.indexOf(${methodVariable})) {

--- a/src/Component/Routing/src/Route.js
+++ b/src/Component/Routing/src/Route.js
@@ -12,7 +12,7 @@ class Route {
      * @param {Object.<string, string>} [requirements = {}]
      * @param {Object.<string, *>} [options = {}]
      * @param {string} [host]
-     * @param {string[]} [schemes = []]
+     * @param {string[]} [schemes = [ 'http', 'https' ]]
      * @param {string[]} [methods = [ 'GET', 'POST' ]]
      * @param {string} [condition]
      */
@@ -22,7 +22,7 @@ class Route {
         requirements = {},
         options = {},
         host = undefined,
-        schemes = [],
+        schemes = [ 'http', 'https' ],
         methods = [ 'GET', 'POST' ],
         condition = undefined
     ) {


### PR DESCRIPTION
As stated in the subject, this PR adds websocket support in the HttpFoundation and HttpServer components.

To support websocket communcations the user must extend the `Websocket` class and implement its own `onMessage` and optionally `onClose` methods.

* `onMessage` will be invoked when a message has been completely received from the client and a `Message` object is passed as the first parameter.
* `onClose` will be invoked **just before** a close frame is sent to the client.

The `send` method must be used to push a message to the client, passing an instance of `Message` to be sent.

TODO:

- [x] Name changes `Frame` -> `FrameBuffer`, `Packet` -> `Frame` to be coherent with the spec