### PR TITLE
fix: npm ignore tests directory

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -11,6 +11,6 @@ coverage
 node_modules
 .npm
 package-lock.json
-test/
+./test/
 tests.js
 fixtures


### PR DESCRIPTION
As discussed [here](https://github.com/jymfony/autoloader/pull/2) it looks we should exclude `test` directory from `.npmignore` with a more stringent rule to avoid undesired matches with other paths.